### PR TITLE
Also move metadata to the start event

### DIFF
--- a/apps/voting/contracts/Voting.sol
+++ b/apps/voting/contracts/Voting.sol
@@ -37,7 +37,6 @@ contract Voting is IForwarder, AragonApp {
         uint256 yea;
         uint256 nay;
         uint256 totalVoters;
-        string metadata;
         bytes executionScript;
         bool executed;
         mapping (address => VoterState) voters;
@@ -45,7 +44,7 @@ contract Voting is IForwarder, AragonApp {
 
     Vote[] internal votes; // first index is 1
 
-    event StartVote(uint256 indexed voteId, address indexed creator);
+    event StartVote(uint256 indexed voteId, address indexed creator, string metadata);
     event CastVote(uint256 indexed voteId, address indexed voter, bool supports, uint256 stake);
     event ExecuteVote(uint256 indexed voteId);
     event ChangeMinQuorum(uint256 minAcceptQuorumPct);
@@ -199,10 +198,6 @@ contract Voting is IForwarder, AragonApp {
         script = vote.executionScript;
     }
 
-    function getVoteMetadata(uint256 _voteId) public view returns (string) {
-        return votes[_voteId].metadata;
-    }
-
     function getVoterState(uint256 _voteId, address _voter) public view returns (VoterState) {
         return votes[_voteId].voters[_voter];
     }
@@ -212,12 +207,11 @@ contract Voting is IForwarder, AragonApp {
         Vote storage vote = votes[voteId];
         vote.executionScript = _executionScript;
         vote.startDate = uint64(now);
-        vote.metadata = _metadata;
         vote.snapshotBlock = getBlockNumber() - 1; // avoid double voting in this very block
         vote.totalVoters = token.totalSupplyAt(vote.snapshotBlock);
         vote.minAcceptQuorumPct = minAcceptQuorumPct;
 
-        StartVote(voteId, msg.sender);
+        StartVote(voteId, msg.sender, _metadata);
 
         if (_castVote && canVote(voteId, msg.sender)) {
             _vote(

--- a/apps/voting/test/voting.js
+++ b/apps/voting/test/voting.js
@@ -133,6 +133,7 @@ contract('Voting App', accounts => {
                 const startVote = startVoteEvent(await app.newVote(script, 'metadata', false, { from: holder50 }))
                 voteId = startVote.voteId
                 creator = startVote.creator
+                metadata = startVote.metadata
             })
 
             it('has correct state', async () => {
@@ -147,7 +148,7 @@ contract('Voting App', accounts => {
                 assert.equal(n, 0, 'initial nay should be 0')
                 assert.equal(totalVoters, 100, 'total voters should be 100')
                 assert.equal(execScript, script, 'script should be correct')
-                assert.equal(await app.getVoteMetadata(voteId), 'metadata', 'should have returned correct metadata')
+                assert.equal(metadata, 'metadata', 'should have returned correct metadata')
                 assert.equal(await app.getVoterState(voteId, nonHolder), VOTER_STATE.ABSENT, 'nonHolder should not have voted')
             })
 


### PR DESCRIPTION
Similar to https://github.com/aragon/aragon-apps/pull/434, this also moves metadata to event data, which saves even more gas.